### PR TITLE
fix: filesizelimit is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note: Remember to configure the branch protection rule and select the `LFS-warni
 
 ### `filesizelimit`
 
-Required, set's the file size limit threshold. Accepts `b` (bytes), `mb` (megabytes) and `gb` (gigabytes) as units of measurement, if omitted interprets as bytes.
+Optional. set's the file size limit threshold. Accepts `b` (bytes), `mb` (megabytes) and `gb` (gigabytes) as units of measurement, if omitted interprets as bytes.
 
 Default `10mb`.
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: ${{ github.token }}
   filesizelimit: # id of input
     description: "file size limit threshold"
-    required: true
+    required: false
     default: "10mb"
   exclusionPatterns:
     required: false


### PR DESCRIPTION
The filesizelimit argument defaults to 10mb, it is not required.
