### PR TITLE
Exclude blobs without sha when getting PR files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12806,7 +12806,10 @@ async function getPrFilesWithBlobSize(pullRequestNumber) {
             return !isExcluded;
         })
         : data;
-    const prFilesWithBlobSize = await Promise.all(files.map(async (file) => {
+    const prFilesWithBlobSize = await Promise.all(files
+        // Cannot get blobs for files without sha (e.g. happens when only changing a permission bit on the file)
+        .filter(file => file.sha != null)
+        .map(async (file) => {
         const { filename, sha, patch } = file;
         const { data: blob } = await octokit.rest.git.getBlob({
             ...repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,21 +198,24 @@ async function getPrFilesWithBlobSize(pullRequestNumber: number) {
       : data;
 
   const prFilesWithBlobSize = await Promise.all(
-    files.map(async file => {
-      const {filename, sha, patch} = file;
-      const {data: blob} = await octokit.rest.git.getBlob({
-        ...repo,
-        file_sha: sha,
-      });
+    files
+      // Cannot get blobs for files without sha (e.g. happens when only changing a permission bit on the file)
+      .filter(file => file.sha != null)
+      .map(async file => {
+        const {filename, sha, patch} = file;
+        const {data: blob} = await octokit.rest.git.getBlob({
+          ...repo,
+          file_sha: sha,
+        });
 
-      return {
-        filename,
-        filesha: sha,
-        fileblobsize: blob.size,
-        filecontents: blob.content,
-        patch,
-      };
-    })
+        return {
+          filename,
+          filesha: sha,
+          fileblobsize: blob.size,
+          filecontents: blob.content,
+          patch,
+        };
+      })
   );
   return prFilesWithBlobSize;
 }


### PR DESCRIPTION
When only changing a permission bit on a file, GitHub returns a `null` sha when listing the PR files. Getting the blob then fails and in turn fails the action.