### PR TITLE
update node js to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
   lfsFiles: # output will be available to future steps
     description: "Array of possible detected large file(s)"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "alert-triangle" # icon referenced from https://feathericons.com/


### PR DESCRIPTION
GitHub is deprecating 12 for some reason.  Hopefully this just works.