### PR TITLE
Update README to be clear a checkout is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,15 @@ Returns an array of possible detected large file(s)
 Consume the action by referencing the stable release
 
 ```yaml
-uses: ppremk/lfs-warning@v3.2
-with:
-  token: ${{ secrets.GITHUB_TOKEN }} # Optional
-  filesizelimit: 10MB
-  exclusionPatterns: |
-    **/*.png
+- name: Checkout
+  uses: actions/checkout@v4
+
+- uses: ppremk/lfs-warning@v3.2
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }} # Optional
+    filesizelimit: 10MB
+    exclusionPatterns: |
+      **/*.png
 ```
 
 ## Contributers
@@ -75,4 +78,5 @@ with:
 - [@srz-zumix](https://github.com/srz-zumix)
 - [@zzgab](https://github.com/zzgab)
 - [@samthebest](https://github.com/samthebest)
+- [@benmccallum](https://github.com/benmccallum)
 


### PR DESCRIPTION
Seems latest versions require the caller to do their own explicit checkout.