### PR TITLE
Add sendComment input

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Optional. The name of the label, defaults to lfs-detected!
 
 Optional. The color of the label, defaults to ff1493.
 
+### `sendComment`
+
+Optional. If set to false, disables sending comments.
+
+Default `true`.
+
 ## Outputs
 
 ### `lfsFiles`

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     required: false
     default: ff1493
     description: The color of the label, defaults to ff1493
+  sendComment:
+    required: false
+    default: true
+    description: Disable sending comments
 outputs:
   lfsFiles: # output will be available to future steps
     description: "Array of possible detected large file(s)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,23 +87,28 @@ async function run() {
     if (lsfFiles.length > 0) {
       core.info('Detected file(s) that should be in LFS: ');
       core.info(lsfFiles.join('\n'));
+      
+      const send_comment = core.getInput('sendComment');
+      if (send_comment === "" || send_comment === "true") {
+        const body = getCommentBody(
+          largeFiles,
+          accidentallyCheckedInLsfFiles,
+          fsl
+        );
 
-      const body = getCommentBody(
-        largeFiles,
-        accidentallyCheckedInLsfFiles,
-        fsl
-      );
-
-      await Promise.all([
-        octokit.rest.issues.addLabels({
-          ...issueBaseProps,
-          labels: [labelName],
-        }),
-        octokit.rest.issues.createComment({
-          ...issueBaseProps,
-          body,
-        }),
-      ]);
+        await Promise.all([
+          octokit.rest.issues.addLabels({
+            ...issueBaseProps,
+            labels: [labelName],
+          }),
+          octokit.rest.issues.createComment({
+            ...issueBaseProps,
+            body,
+          }),
+        ]);
+      } else if (send_comment !== "false") {
+        throw new Error("sendComment must be either true or false");
+      }
 
       core.setOutput('lfsFiles', lsfFiles);
       core.setFailed(

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,18 @@ async function run() {
     if (lsfFiles.length > 0) {
       core.info('Detected file(s) that should be in LFS: ');
       core.info(lsfFiles.join('\n'));
+
+      core.setOutput('lfsFiles', lsfFiles);
+      core.setFailed(
+        'Large file(s) detected! Setting PR status to failed. Consider using git-lfs to track the LFS file(s)'
+      );
+
+      await Promise.all([
+        octokit.rest.issues.addLabels({
+          ...issueBaseProps,
+          labels: [labelName],
+        }),
+      ]);
       
       const send_comment = core.getInput('sendComment');
       if (send_comment === "" || send_comment === "true") {
@@ -97,10 +109,6 @@ async function run() {
         );
 
         await Promise.all([
-          octokit.rest.issues.addLabels({
-            ...issueBaseProps,
-            labels: [labelName],
-          }),
           octokit.rest.issues.createComment({
             ...issueBaseProps,
             body,
@@ -109,11 +117,6 @@ async function run() {
       } else if (send_comment !== "false") {
         throw new Error("sendComment must be either true or false");
       }
-
-      core.setOutput('lfsFiles', lsfFiles);
-      core.setFailed(
-        'Large file(s) detected! Setting PR status to failed. Consider using git-lfs to track the LFS file(s)'
-      );
     } else {
       core.info('No large file(s) detected...');
 


### PR DESCRIPTION
related: #168

Disables comment creation when `sendComment` is false.

I've got it working, but I think `Promise.all([...])` should be replaced with something else. As I'm not familiar with TypeScript, I'd appreciate any feedback on it.
